### PR TITLE
Fixes issue #24 part 2, eliminate all existing error handling and just use global exception handler

### DIFF
--- a/NuGet/content/bundler/bundler.js
+++ b/NuGet/content/bundler/bundler.js
@@ -26,7 +26,7 @@ SOFTWARE.
 // with an exit code that will be identified as a failure by most
 // windows build systems
 process.on("uncaughtException", function (err) {
-    console.log(err);
+    console.error(err);
     process.exit(1);
 });
 
@@ -81,7 +81,7 @@ var fs = require("fs"),
 var walk = function (dir, done) {
     var results = [];
     fs.readdir(dir, function (err, list) {
-        if (err) return done(err);
+        if (err) throw err;
         var i = 0;
         (function next() {
             var file = list[i++];
@@ -414,13 +414,8 @@ function compileAsync(mode, compileFn /*compileFn(text, textPath, cb(compiledTex
                         cb(minText);
                     });
                 };
-                try {
-                    compileFn(text, textPath, onAfterCompiled);
-                } catch (e) {
-                    console.log(e);
-                }
-            }
-            else {
+                compileFn(text, textPath, onAfterCompiled);
+            } else {
                 readTextFile(compileTextPath, cb);
             }
         }
@@ -436,7 +431,7 @@ function compileLess(lessCss, lessPath, cb) {
         };
     
     less.render(lessCss, options, function (err, css) {
-        if (err) return cb("") && console.error(err);
+        if (err) throw err;
         cb(css);
     });
 }

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -26,7 +26,7 @@ SOFTWARE.
 // with an exit code that will be identified as a failure by most
 // windows build systems
 process.on("uncaughtException", function (err) {
-    console.log(err);
+    console.error(err);
     process.exit(1);
 });
 
@@ -81,7 +81,7 @@ var fs = require("fs"),
 var walk = function (dir, done) {
     var results = [];
     fs.readdir(dir, function (err, list) {
-        if (err) return done(err);
+        if (err) throw err;
         var i = 0;
         (function next() {
             var file = list[i++];
@@ -414,13 +414,8 @@ function compileAsync(mode, compileFn /*compileFn(text, textPath, cb(compiledTex
                         cb(minText);
                     });
                 };
-                try {
-                    compileFn(text, textPath, onAfterCompiled);
-                } catch (e) {
-                    console.log(e);
-                }
-            }
-            else {
+                compileFn(text, textPath, onAfterCompiled);
+            } else {
                 readTextFile(compileTextPath, cb);
             }
         }
@@ -436,7 +431,7 @@ function compileLess(lessCss, lessPath, cb) {
         };
     
     less.render(lessCss, options, function (err, css) {
-        if (err) return cb("") && console.error(err);
+        if (err) throw err;
         cb(css);
     });
 }

--- a/tests/Bootstrap.Mvc/bundler/bundler.js
+++ b/tests/Bootstrap.Mvc/bundler/bundler.js
@@ -26,7 +26,7 @@ SOFTWARE.
 // with an exit code that will be identified as a failure by most
 // windows build systems
 process.on("uncaughtException", function (err) {
-    console.log(err);
+    console.error(err);
     process.exit(1);
 });
 
@@ -81,7 +81,7 @@ var fs = require("fs"),
 var walk = function (dir, done) {
     var results = [];
     fs.readdir(dir, function (err, list) {
-        if (err) return done(err);
+        if (err) throw err;
         var i = 0;
         (function next() {
             var file = list[i++];
@@ -414,13 +414,8 @@ function compileAsync(mode, compileFn /*compileFn(text, textPath, cb(compiledTex
                         cb(minText);
                     });
                 };
-                try {
-                    compileFn(text, textPath, onAfterCompiled);
-                } catch (e) {
-                    console.log(e);
-                }
-            }
-            else {
+                compileFn(text, textPath, onAfterCompiled);
+            } else {
                 readTextFile(compileTextPath, cb);
             }
         }
@@ -436,7 +431,7 @@ function compileLess(lessCss, lessPath, cb) {
         };
     
     less.render(lessCss, options, function (err, css) {
-        if (err) return cb("") && console.error(err);
+        if (err) throw err;
         cb(css);
     });
 }


### PR DESCRIPTION
This commit replaces all existing exception handling to allow errors to flow up to the global handler.  This ensures that any error will get caught by the global error handler and cause bundler to exit with a non 0 exit code.  This causes a problem with the VS extension because it is not correctly picking up the writes to stderr.  The bundler extension still does everything else correctly.

This has been tested to crash a build in VS and can easily be tested from the command line by calling `ECHO %ERRORLEVEL%` after running it.
