### PR TITLE
Fixed skipremin behavior and added two new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ The currently available options are:
   - **nobundle** - Compiles and minifies all files listed, however it does not bundle them into a single file. This allows you to compile and minify your standalone files without concatenating them into a bundle.
   - **skipmin** - Skips the minimization step for every file
   - **skipremin** - Skips the minification step for files that already contain a '.min.' or '.pack.' in their filename. This lowers the chance of multiple minification iterations introducing problems.
-  - **folder** - Used a trigger to transform all files in the folder with this bundle file. If the `recursive` value is used, a seek will search recursively from this root transforming all files in all folders searched. When the `folder` option is used, the `nobundle` option is automatically set. When the `folder` option is used, listing files in the bundle file does nothing.
+  - **folder** - Used as a trigger to transform all files in the folder with this bundle file. If the `recursive` value is used, a seek will search recursively from this root transforming all files in all folders searched. When the `folder` option is used, the `nobundle` option is automatically set. When the `folder` option is used, listing files in the bundle file does nothing.
+  - **outputbundleonly** - Does not create individual .min files for each file in the bundle. The bundled file is the only output.
+  - **bundleminonly** - Does not create a non-minimized version of the bundle file. Only creates the .min version of the bundle.
 
 Tip: If you just want bundler to transform all the files in your content folder, add a bundle file in the root of the content folder and set its contents to the following:
 


### PR DESCRIPTION
I discovered that the skipremin option would not add any .min. files to the bundle.min.css|js file, so I fixed that implementation.
I also did not like having bundler creating an individual .min file for every .js or .css file listed in a bundle, so I created the outputbundleonly option to force bundler to only output the bundle.min.css|js and bundle.css|js.
Then I decided I wanted ONLY the bundle.min.css|js file, so I added another option: bundleminonly.  When used, it only outputs the minimized version of the bundle file (complete with the .min. filename segment) and skips creating the non-minimized version.
