### PR TITLE
Add URL render function

### DIFF
--- a/NuGet/content/Mvc.Bundler.cs
+++ b/NuGet/content/Mvc.Bundler.cs
@@ -284,7 +284,7 @@ namespace ServiceStack.Mvc
 
 			bundlePath = bundlePath.Replace(".bundle", "");
 			if (options == BundleOptions.MinifiedAndCombined)
-				return bundlePath.Insert(bundlePath.LastIndexOf("."), ".min");
+				bundlePath = bundlePath.Insert(bundlePath.LastIndexOf("."), ".min");
 			
 			return bundlePath.RewriteUrl(options);
 		}


### PR DESCRIPTION
Implements a wrapper around RewriteUrl() to get the URL to the bundle, rather than a full tag, to save having to munge the tag returned from RenderJsBundle() to get to the URL

Only implemented for combined bundles as that's all I have
