### PR TITLE
Incorrect links generated within a sub-application

### DIFF
--- a/NuGet/content/Mvc.Bundler.cs
+++ b/NuGet/content/Mvc.Bundler.cs
@@ -153,7 +153,7 @@ namespace ServiceStack.Mvc
 				return MvcHtmlString.Empty;
 
 			if (href.StartsWith("~/"))
-				href = href.Replace("~/", VirtualPathUtility.ToAbsolute("~"));
+				href = VirtualPathUtility.ToAbsolute(href);
 
 			var tag = new TagBuilder("link");
 			tag.MergeAttribute("rel", rel);
@@ -184,7 +184,7 @@ namespace ServiceStack.Mvc
 				return MvcHtmlString.Empty;
 
 			if (src.StartsWith("~/"))
-				src = src.Replace("~/", VirtualPathUtility.ToAbsolute("~"));
+				src = VirtualPathUtility.ToAbsolute(src);
 
 			var tag = new TagBuilder("img");
 
@@ -210,7 +210,7 @@ namespace ServiceStack.Mvc
 				return MvcHtmlString.Empty;
 
 			if (src.StartsWith("~/"))
-				src = src.Replace("~/", VirtualPathUtility.ToAbsolute("~"));
+				src = VirtualPathUtility.ToAbsolute(src);
 
 			var tag = new TagBuilder("script");
 			tag.MergeAttribute("type", "text/javascript");


### PR DESCRIPTION
If we generate a link to "~/content/test.js" within an application "Test", VirtualPathUtility.ToAbsolute("~") will return "/Test" so Replace("~/", VirtualPathUtility.ToAbsolute("~")) returns "/Testcontent/test.js".
