### PR TITLE
Updated Bundler.cs VirtualPathUtility.ToAbsolute

### DIFF
--- a/NuGet/Bundler/content/Bundler.cs
+++ b/NuGet/Bundler/content/Bundler.cs
@@ -197,7 +197,7 @@ namespace ServiceStack.Html
                 return MvcHtmlString.Empty;
 
             if (href.StartsWith("~/"))
-                href = href.Replace("~/", VirtualPathUtility.ToAbsolute("~"));
+                href = href.Replace("~/", VirtualPathUtility.ToAbsolute("~/"));
 
             var tag = new TagBuilder("link");
             tag.MergeAttribute("rel", rel);
@@ -228,7 +228,7 @@ namespace ServiceStack.Html
                 return MvcHtmlString.Empty;
 
             if (src.StartsWith("~/"))
-                src = src.Replace("~/", VirtualPathUtility.ToAbsolute("~"));
+                src = src.Replace("~/", VirtualPathUtility.ToAbsolute("~/"));
 
             var tag = new TagBuilder("img");
 
@@ -254,7 +254,7 @@ namespace ServiceStack.Html
                 return MvcHtmlString.Empty;
 
             if (src.StartsWith("~/"))
-                src = src.Replace("~/", VirtualPathUtility.ToAbsolute("~"));
+                src = src.Replace("~/", VirtualPathUtility.ToAbsolute("~/"));
 
             var tag = new TagBuilder("script");
             tag.MergeAttribute("type", "text/javascript");


### PR DESCRIPTION
If a website is not sitting in the root folder of the server the URLs are not made relative correctly.
Eg
WebApp sits under /MyProject/

Renderer Urls look like: /MyProjectscripts/jquery.js
Urls must look like: /MyProject/scripts/jquery.js
