### PR TITLE
MapServerPath for broader SS env coverage

### DIFF
--- a/tests/Bundler.ServiceStack/Bundler.cs
+++ b/tests/Bundler.ServiceStack/Bundler.cs
@@ -37,7 +37,7 @@ namespace ServiceStack.Html
         {
             var mvcControllerExists = AppDomain.CurrentDomain.GetAssemblies().Any(x => x.GetType("System.Web.Mvc.Controller") != null);
             UseMvc = mvcControllerExists;
-            MapPathFallbackFn = MapHostAbsolutePath;
+            MapPathFallbackFn = s => s.MapServerPath();
         }
 
         // Logic to determine if the app is running in production or dev environment


### PR DESCRIPTION
I can confirm the following configuration fails with the current implementation:

ServiceStack VS Template (blank) self-hosted in a x64 build configuration (3 dirs deep: "bin\x64\Debug\").

Using `string.MapServerPath` fixes it.  Mainly due to `MapHostAbsolutePath` forcing a "../" which traverses up to the parent directory (ie. "bin\x64\") before evaluating the rest of the virtual path (ie. "Content\app.css.bundle").  So instead of "bin\x64\Debug\Content\app.css.bundle", the caller receives "bin\x64\Content\app.css.bundle" and chaos ensues.

Proposing the attached file change to use `MapServerPath`.  This is in favour of the only way to get around the issue without source modification to SS libraries (via a static replacement of the function):

    Bundler.MapPathFallbackFn = s => s.MapServerPath(); // in AppHost